### PR TITLE
Add pprof debug endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Full configuration example:
 # allow debug outputs
 debug: true
 
+# mount debug pprof endpoint at /debug/pprof/
+pprof: true
+
 # bind server to IP:PORT (use :8888 for all connections)
 bind: localhost:8888
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,12 +11,18 @@ import (
 
 type Root struct {
 	Debug   bool
+	PProf   bool
 	CfgFile string
 }
 
 func (Root) Init(cmd *cobra.Command) error {
 	cmd.PersistentFlags().BoolP("debug", "d", false, "enable debug mode")
 	if err := viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("pprof", false, "enable pprof endpoint available at /debug/pprof")
+	if err := viper.BindPFlag("pprof", cmd.PersistentFlags().Lookup("pprof")); err != nil {
 		return err
 	}
 
@@ -30,6 +36,7 @@ func (Root) Init(cmd *cobra.Command) error {
 
 func (s *Root) Set() {
 	s.Debug = viper.GetBool("debug")
+	s.PProf = viper.GetBool("pprof")
 	s.CfgFile = viper.GetString("config")
 }
 

--- a/internal/http/debug.go
+++ b/internal/http/debug.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/go-chi/chi"
+)
+
+func (s *HttpManagerCtx) WithDebugPProf(pathPrefix string) {
+	s.router.Route(pathPrefix, func(r chi.Router) {
+		r.Get("/", pprof.Index)
+
+		r.Get("/{action}", func(w http.ResponseWriter, r *http.Request) {
+			action := chi.URLParam(r, "action")
+
+			switch action {
+			case "cmdline":
+				pprof.Cmdline(w, r)
+			case "profile":
+				pprof.Profile(w, r)
+			case "symbol":
+				pprof.Symbol(w, r)
+			case "trace":
+				pprof.Trace(w, r)
+			default:
+				pprof.Handler(action).ServeHTTP(w, r)
+			}
+		})
+	})
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -45,6 +45,12 @@ func (main *Main) Start() {
 	main.httpManager.Mount(main.apiManager.Mount)
 	main.httpManager.Start()
 
+	if main.RootConfig.PProf {
+		pathPrefix := "/debug/pprof/"
+		main.httpManager.WithDebugPProf(pathPrefix)
+		main.logger.Info().Msgf("mounted debug pprof endpoint at %s", pathPrefix)
+	}
+
 	main.logger.Info().Msgf("serving streams from basedir %s: %s", config.BaseDir, config.Streams)
 }
 


### PR DESCRIPTION
This endpoint should help with debugging in the future.

More info here: https://pkg.go.dev/net/http/pprof


---
Types of profiles available:

- allocs
- block
- cmdline
- goroutine
- heap
- mutex
- profile
- threadcreate
- trace

<p>
Profile Descriptions:
</p><ul>
<li><div class="profile-name">allocs: </div> A sampling of all past memory allocations</li>
<li><div class="profile-name">block: </div> Stack traces that led to blocking on synchronization primitives</li>
<li><div class="profile-name">cmdline: </div> The command line invocation of the current program</li>
<li><div class="profile-name">goroutine: </div> Stack traces of all current goroutines</li>
<li><div class="profile-name">heap: </div> A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.</li>
<li><div class="profile-name">mutex: </div> Stack traces of holders of contended mutexes</li>
<li><div class="profile-name">profile: </div> CPU profile. You can 
specify the duration in the seconds GET parameter. After you get the 
profile file, use the go tool pprof command to investigate the profile.</li>
<li><div class="profile-name">threadcreate: </div> Stack traces that led to the creation of new OS threads</li>
<li><div class="profile-name">trace: </div> A trace of execution of the 
current program. You can specify the duration in the seconds GET 
parameter. After you get the trace file, use the go tool trace command 
to investigate the trace.</li>
</ul>