### PR TITLE
Fix invalid segment times

### DIFF
--- a/hlsvod/manager.go
+++ b/hlsvod/manager.go
@@ -365,8 +365,12 @@ func (m *ManagerCtx) waitForSegment(index int) (chan struct{}, bool) {
 func (m *ManagerCtx) transcodeSegments(offset, limit int) error {
 	logger := m.logger.With().Int("offset", offset).Int("limit", limit).Logger()
 
-	segmentTimes := m.breakpoints[offset : offset+limit+1]
+	segmentTimes := m.breakpoints[offset : offset+limit]
 	logger.Info().Interface("segments-times", segmentTimes).Msg("transcoding segments")
+
+	if len(segmentTimes) == 0 {
+		return nil
+	}
 
 	segments, err := TranscodeSegments(m.ctx, m.config.FFmpegBinary, TranscodeConfig{
 		InputFilePath: m.config.MediaPath,


### PR DESCRIPTION
I'm not familiar with this code, but I needed this change to get anything to work. Basically the `limit` was larger than the size of the breakpoints slice, so it ended up with a zero at the end for `segmentTimes`. This cause the ffmpeg call to fail because the end time is zero.
If it matters, I'm testing with very short videos (~10s)