### PR TITLE
Web player improvements

### DIFF
--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -20,16 +20,23 @@
             var player = videojs("my_player");
             player.hlsQualitySelector({displayCurrentQuality:true});
             player.src("index.m3u8");
-            player.play();
 
+            // Play on manual button click
             document.getElementById("my_player").addEventListener("click", function(){
                 player.play();
             }, {once: true});
 
-            // try to autoplay after 500ms
-            setTimeout(function() {
-                player.play();
-            }, 500)
+            // Try to autoplay once the player is ready
+            // (no guarantee it will work: https://videojs.com/blog/autoplay-best-practices-with-video-js/)
+            player.on('canplay', function(){
+              var promise = player.play();
+
+              promise.then(function() {
+                // OK
+              }).catch(function(error) {
+                console.log("Couldn't autoplay, please play manually.", error)
+              });
+            })
         </script>
     </body>
 </html>

--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -33,20 +33,28 @@
             });
 
             // Play on manual button click
+            var hasFirstPlayed = false
             document.getElementById("my_player").addEventListener("click", function(){
-                player.play();
+              hasFirstPlayed = true
+              player.play();
             }, {once: true});
 
             // Try to autoplay once the player is ready
-            // (no guarantee it will work: https://videojs.com/blog/autoplay-best-practices-with-video-js/)
+            // No guarantee it will work: https://videojs.com/blog/autoplay-best-practices-with-video-js/
+            // Note: using canplay event instead of ready, as it fires *after* all the streams are loaded,
+            // but hasFirstPlayed check is because canplay gets fired multiple times (i.e. when switching streams
             player.on('canplay', function(){
-              var promise = player.play();
+              if(!hasFirstPlayed){
+                hasFirstPlayed = true
 
-              promise.then(function() {
-                // OK
-              }).catch(function(error) {
-                console.log("Couldn't autoplay, please play manually.", error)
-              });
+                console.log("Trying to autoplay...")
+                var promise = player.play();
+                promise.then(function() {
+                  console.log("Playback started")
+                }).catch(function(error) {
+                  console.log("Couldn't autoplay, please play manually.", error)
+                });
+              }
             })
         </script>
     </body>

--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -18,7 +18,7 @@
 
         <script>
             var player = videojs("my_player");
-            player.hlsQualitySelector();
+            player.hlsQualitySelector({displayCurrentQuality:true});
             player.src("index.m3u8");
             player.play();
 

--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -20,6 +20,7 @@
             var player = videojs("my_player");
             var qualities = player.qualityLevels();
             var qualitySelector = player.hlsQualitySelector({displayCurrentQuality:true});
+            player.src("index.m3u8");
 
             // Logging
             qualities.on('addqualitylevel', () =>{
@@ -30,8 +31,6 @@
               var q = qualities[qualities.selectedIndex]
               console.log(`Stream selected: ${q.height}: "${q.label}"`);
             });
-
-            player.src("index.m3u8");
 
             // Play on manual button click
             document.getElementById("my_player").addEventListener("click", function(){

--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -23,7 +23,7 @@
             player.src("index.m3u8");
 
             // Logging
-            qualities.on('addqualitylevel', () =>{
+            qualities.on('addqualitylevel', () => {
               var q = qualities[qualities.length - 1]
               console.log(`Stream loaded: ${q.height}: "${q.label}"`)
             });
@@ -31,6 +31,29 @@
               var q = qualities[qualities.selectedIndex]
               console.log(`Stream selected: ${q.height}: "${q.label}"`);
             });
+
+            // If a query arg is present, try to set the default player quality
+            const requestedQuality = parseInt(new URLSearchParams(window.location.search).get('quality'))
+            if(requestedQuality) {
+
+              var requestedQualityWasFound = false
+              qualities.on('addqualitylevel', () => {
+
+                // Don't do anything until we've loaded a stream that matches the requested quality
+                var q = qualities[qualities.length - 1]
+                if (q.height === requestedQuality) {
+                  console.log(`Requested quality found; changing stream to: "${q.label}"`)
+                  requestedQualityWasFound = true
+                }
+                if (!requestedQualityWasFound)
+                  return
+
+                // If we find the requested quality, set it
+                // Note: Intentionally continuing to call this for all qualities that are loaded after the one that was requested;
+                // doesn't work otherwise!
+                qualitySelector.setQuality(requestedQuality);
+              })
+            }
 
             // Play on manual button click
             var hasFirstPlayed = false

--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -18,7 +18,19 @@
 
         <script>
             var player = videojs("my_player");
-            player.hlsQualitySelector({displayCurrentQuality:true});
+            var qualities = player.qualityLevels();
+            var qualitySelector = player.hlsQualitySelector({displayCurrentQuality:true});
+
+            // Logging
+            qualities.on('addqualitylevel', () =>{
+              var q = qualities[qualities.length - 1]
+              console.log(`Stream loaded: ${q.height}: "${q.label}"`)
+            });
+            qualities.on('change', ()=> {
+              var q = qualities[qualities.selectedIndex]
+              console.log(`Stream selected: ${q.height}: "${q.label}"`);
+            });
+
             player.src("index.m3u8");
 
             // Play on manual button click

--- a/internal/api/play.html
+++ b/internal/api/play.html
@@ -27,7 +27,7 @@
               var q = qualities[qualities.length - 1]
               console.log(`Stream loaded: ${q.height}: "${q.label}"`)
             });
-            qualities.on('change', ()=> {
+            qualities.on('change', () => {
               var q = qualities[qualities.selectedIndex]
               console.log(`Stream selected: ${q.height}: "${q.label}"`);
             });
@@ -39,7 +39,7 @@
               var requestedQualityWasFound = false
               qualities.on('addqualitylevel', () => {
 
-                // Don't do anything until we've loaded a stream that matches the requested quality
+                // Don't do anything until actually load a stream that matches the requested quality
                 var q = qualities[qualities.length - 1]
                 if (q.height === requestedQuality) {
                   console.log(`Requested quality found; changing stream to: "${q.label}"`)
@@ -48,9 +48,8 @@
                 if (!requestedQualityWasFound)
                   return
 
-                // If we find the requested quality, set it
-                // Note: Intentionally continuing to call this for all qualities that are loaded after the one that was requested;
-                // doesn't work otherwise!
+                // Once we find the requested quality, set it. Note: Intentionally continuing to call this
+                // for all qualities that are loaded after the one that was requested - doesn't work otherwise!
                 qualitySelector.setQuality(requestedQuality);
               })
             }
@@ -64,8 +63,8 @@
 
             // Try to autoplay once the player is ready
             // No guarantee it will work: https://videojs.com/blog/autoplay-best-practices-with-video-js/
-            // Note: using canplay event instead of ready, as it fires *after* all the streams are loaded,
-            // but hasFirstPlayed check is because canplay gets fired multiple times (i.e. when switching streams
+            // Note: Using 'canplay' event instead of 'ready' as it fires *after* all the streams are loaded;
+            // hasFirstPlayed check is because canplay can fire multiple times (i.e. when manually switching streams)
             player.on('canplay', function(){
               if(!hasFirstPlayed){
                 hasFirstPlayed = true


### PR DESCRIPTION
A few things for the html player:

* Add the ability to specify the initial/default quality via query arg, i.e. `?quality=540` will cause the player to initially select the 540p profile
* Show the currently selected profile name on the player UI
* Fix autoplay by triggering it after all the streams have loaded